### PR TITLE
Enable asymmetric y-axes via user-input parameter to `ggmiami` or `prep_miami_data` and improve plot alignment

### DIFF
--- a/R/ggmiami.R
+++ b/R/ggmiami.R
@@ -165,8 +165,8 @@ ggmiami <- function(
 
   # Set separate y-axis limits in case symmetry is broken by user on purpose
   if (split_p) {
-    upper_maxp = plot_data$upper_maxp
-    lower_maxp = plot_data$lower_maxp
+    upper_maxp = plot_data$upper.maxp
+    lower_maxp = plot_data$lower.maxp
   } else {
     upper_maxp = plot_data$maxp
     lower_maxp = plot_data$maxp

--- a/R/ggmiami.R
+++ b/R/ggmiami.R
@@ -118,11 +118,12 @@ ggmiami <- function(
   upper_highlight_color = "green",
   lower_highlight = NULL,
   lower_highlight_col = NULL,
-  lower_highlight_color = "green") {
+  lower_highlight_color = "green",
+  split_p = FALSE) {
 
   # Prepare the data
   plot_data <- prep_miami_data(data = data, split_by = split_by,
-                               split_at = split_at, chr = chr, pos = pos, p = p)
+                               split_at = split_at, chr = chr, pos = pos, p = p, split_p = split_p)
 
   # Double check that the colors are specified correctly. Will incorporate them
   # after the plot is called.
@@ -162,6 +163,15 @@ ggmiami <- function(
   # Then in ggplot2 call: axis.title.y = ggtext::element_markdown() and un-set
   # the l margin.
 
+  # Set separate y-axis limits in case symmetry is broken by user on purpose
+  if (split_p) {
+    upper_maxp = plot_data$upper_maxp
+    lower_maxp = plot_data$lower_maxp
+  } else {
+    upper_maxp = plot_data$maxp
+    lower_maxp = plot_data$maxp
+  }
+
   # Create base upper plot.
   upper_plot <- ggplot2::ggplot() +
     ggplot2::geom_point(data = plot_data$upper,
@@ -172,7 +182,7 @@ ggmiami <- function(
                                 expand = ggplot2::expansion(mult = 0.01),
                                 guide = ggplot2::guide_axis(check.overlap =
                                                               TRUE)) +
-    ggplot2::scale_y_continuous(limits = c(0, plot_data$maxp),
+    ggplot2::scale_y_continuous(limits = c(0, upper_maxp),
                                 expand =
                                   ggplot2::expansion(mult = c(0.02, 0))) +
     ggplot2::labs(x = "", y = upper_ylab) +
@@ -189,7 +199,7 @@ ggmiami <- function(
     ggplot2::scale_x_continuous(breaks = plot_data$axis$chr_center,
                                 position = "top",
                                 expand = ggplot2::expansion(mult = 0.01)) +
-    ggplot2::scale_y_reverse(limits = c(plot_data$maxp, 0),
+    ggplot2::scale_y_reverse(limits = c(lower_maxp, 0),
                              expand = ggplot2::expansion(mult = c(0, 0.02))) +
     ggplot2::labs(x = "", y = lower_ylab) +
     ggplot2::theme_classic() +

--- a/R/ggmiami.R
+++ b/R/ggmiami.R
@@ -415,6 +415,9 @@ ggmiami <- function(
   }
 
   # Put the two together
-  gridExtra::grid.arrange(upper_plot, lower_plot, nrow = 2)
+  gUpper <- ggplotGrob(upper_plot)
+  gLower <- ggplotGrob(lower_plot)
+  grid::grid.newpage()
+  grid::grid.draw(rbind(gUpper, gLower))
 
 }

--- a/R/prep_miami_data.R
+++ b/R/prep_miami_data.R
@@ -35,7 +35,8 @@ prep_miami_data <- function(
   split_at,
   chr = "chr",
   pos = "pos",
-  p  =  "p") {
+  p  =  "p",
+  split_p = FALSE) {
 
   # Check the required input
   check_miami_input(data = data, split_by = split_by, split_at = split_at,
@@ -81,9 +82,6 @@ prep_miami_data <- function(
     dplyr::mutate(logged_p = -log10(!!rlang::sym(p))) %>%
     dplyr::rename(chr = as.name(chr))
 
-  # To create a symmetric looking plot, calculate the maximum p-value
-  maxp <- ceiling(max(data$logged_p, na.rm = TRUE))
-
   # Depending on what the user has input for split_by and split_at, make upper
   # and lower plot data.
   if (is.numeric(split_at)) {
@@ -105,8 +103,21 @@ prep_miami_data <- function(
       dplyr::filter(!!rlang::sym(split_by) != split_at)
 
   }
+  
+  # To create a symmetric looking plot, calculate the maximum p-value
+  maxp <- ceiling(max(data$logged_p, na.rm = TRUE))
 
-  miami_data_list <- list("upper" = upper_data, "lower" = lower_data,
+  # To handle future plots with free y-axis scales:
+  if (split_p) {
+      upper_maxp <- ceiling(max(upper_data$logged_p, na.rm = TRUE))
+      lower_maxp <- ceiling(max(lower_data$logged_p, na.rm = TRUE))
+
+      miami_data_list <- list("upper" = upper_data, "lower" = lower_data,
+                          "axis" = axis_data, "maxp" = maxp, "upper.maxp" = upper_maxp, "lower.maxp" = lower_maxp)
+  } else {
+      miami_data_list <- list("upper" = upper_data, "lower" = lower_data,
                           "axis" = axis_data, "maxp" = maxp)
+  }
+  
   return(miami_data_list)
 }


### PR DESCRIPTION
Added a parameter to both `prep_miami_data` and `ggmiami` to enable split y-axis scales as needed for users to whom such use cases are valuable (like me!).

Note: this PR does not fix axis limits when suggestive lines and genome lines exceed the axis limits established by maximum logged p-values, but that will be forthcoming in a future PR should someone else not get to it first.

Fixes issue https://github.com/juliedwhite/miamiplot/issues/5.